### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "cross-env": "^5.2.0",
     "express": "^4.16.4",
     "file-loader": "^3.0.1",
-    "npm": "^6.9.0",
     "nuxt": "^2.4.0",
     "url-loader": "^1.1.2",
     "vee-validate": "^2.2.9",


### PR DESCRIPTION

Hello nestorkx!

It seems like you have npm as one of your (dev-) dependency in portafolio.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
